### PR TITLE
Modification to work with the latest versions of vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,8 +10,8 @@ Vagrant::Config.run do |config|
         ww_config.vm.forward_port 3306, 8889
         ww_config.vm.forward_port 5432, 5433
         ww_config.vm.host_name = "WeBWorK"
-        ww_config.vm.share_folder("webwork2", "/opt/webwork/webwork2", "./webwork2",  :extra => 'dmode=777,fmode=777')
-        ww_config.vm.share_folder("pg", "/opt/webwork/pg", "./pg",  :extra => 'dmode=777,fmode=777')
+        ww_config.vm.share_folder("webwork2", "/opt/webwork/webwork2", "./webwork2",  mount_options: ['dmode=777','fmode=777'])
+        ww_config.vm.share_folder("pg", "/opt/webwork/pg", "./pg",  mount_options:['dmode=777','fmode=777'])
         #ww_config.vm.provision :shell, :inline => "echo \"America/Denver\" | sudo tee /etc/timezone && dpkg-reconfigure --frontend noninteractive tzdata"
     end
 end

--- a/vagrant/ww_install/ww_install.pl
+++ b/vagrant/ww_install/ww_install.pl
@@ -42,7 +42,7 @@
 
 use strict;
 use warnings;
-use lib 'lib';
+use lib '/vagrant/vagrant/ww_install/lib';
 
 use Config;
 
@@ -63,11 +63,11 @@ use DBI;
 
 use Term::UI;
 use Term::ReadLine;
-use Term::ReadPassword #to be found in lib/
+use Term::ReadPassword; #to be found in lib/
 
 
-#use Term::ReadKey;
-#use Data::Dumper;
+# use Term::ReadKey;
+# use Data::Dumper;
 
 ###############################################################################################
 # Create a new Term::Readline object for interactivity


### PR DESCRIPTION
To get it working, I've had to modify the files a little bit.
After it was installed, I had to run cpan to install
Email::Simple
Email::Sender
Data::Dump
Once that was done, webwork2 was up and running through 
http://localhost:8888/webwork2
as expected.